### PR TITLE
:art: add python package descriptions to notes repo

### DIFF
--- a/.github/workflows/build_website.yaml
+++ b/.github/workflows/build_website.yaml
@@ -18,6 +18,10 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
+      
+      - name: Fetch remote files
+        run: |
+          python fetch_files.py
 
       - name: Build the site
         run: |

--- a/README.md
+++ b/README.md
@@ -15,3 +15,12 @@
 
 - find instructions how to create your own technical documentation site using a GitHub template
     at [biosustain/notes_template](https://github.com/biosustain/notes_template)
+
+Here we fetch some markdown files from other sources additionally to the documentation.
+To build locally you need to run:
+
+```bash
+pip install -r requirements.txt
+python fetch_files.py
+python -m sphinx -n -W --keep-going -b html ./ ./_build/
+```

--- a/conf.py
+++ b/conf.py
@@ -4,6 +4,8 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import os
+
 # -- Project information -----------------------------------------------------
 
 project = "Data Science Platform notes"
@@ -59,9 +61,7 @@ nb_execution_raise_on_error = True
 nb_merge_streams = True
 
 # https://myst-nb.readthedocs.io/en/latest/authoring/custom-formats.html#write-custom-formats
-nb_custom_formats = {
-    ".py": ["jupytext.reads", {"fmt": "py:percent"}]
-}
+nb_custom_formats = {".py": ["jupytext.reads", {"fmt": "py:percent"}]}
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -95,3 +95,24 @@ html_theme_options = {
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 # html_static_path = ['_static']
+
+if os.environ.get("READTHEDOCS") == "True":
+    # If we are building on ReadTheDocs, we need to download the output file
+    # from the GitHub repository.
+
+    # Download developing.md from the python_package repository
+    def download_python_package_template_description():
+        from fetch_files import download_and_patch_output
+        
+        download_and_patch_output(
+            repo_url_base="https://github.com/biosustain/python_package/raw/refs/heads/main",
+            file_path_in_repo="developing.md",
+            output_path="python/package_template.md",
+            insert_origin_line=True,
+            insert_origin_line_at=2,
+        )
+
+    def setup(app):
+        # on extensions, see:
+        # https://www.sphinx-doc.org/en/master/usage/extensions/index.html
+        app.connect("builder-inited", download_python_package_template_description)

--- a/conf.py
+++ b/conf.py
@@ -4,8 +4,6 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-import os
-
 # -- Project information -----------------------------------------------------
 
 project = "Data Science Platform notes"
@@ -36,6 +34,7 @@ exclude_patterns = [
     "**/.ipynb_checkpoints/*",
     "jupyter_execute",
     "conf.py",
+    "fetch_files.py",
 ]
 
 
@@ -96,23 +95,3 @@ html_theme_options = {
 # so a file named "default.css" will overwrite the builtin "default.css".
 # html_static_path = ['_static']
 
-if os.environ.get("READTHEDOCS") == "True":
-    # If we are building on ReadTheDocs, we need to download the output file
-    # from the GitHub repository.
-
-    # Download developing.md from the python_package repository
-    def download_python_package_template_description():
-        from fetch_files import download_and_patch_output
-        
-        download_and_patch_output(
-            repo_url_base="https://github.com/biosustain/python_package/raw/refs/heads/main",
-            file_path_in_repo="developing.md",
-            output_path="python/package_template.md",
-            insert_origin_line=True,
-            insert_origin_line_at=2,
-        )
-
-    def setup(app):
-        # on extensions, see:
-        # https://www.sphinx-doc.org/en/master/usage/extensions/index.html
-        app.connect("builder-inited", download_python_package_template_description)

--- a/fetch_files.py
+++ b/fetch_files.py
@@ -1,0 +1,93 @@
+from pathlib import Path, PosixPath
+from typing import Optional
+from urllib.parse import urlparse
+
+import requests
+
+OUTPUT_URL = (
+    "https://github.com/bigbio/quantms/raw/refs/heads/README_links/docs/output.md"
+)
+
+
+def download_file(url, save_path, timeout=20):
+    """
+    Download a file from a URL and save it to the specified path.
+
+    Args:
+        url (str): URL of the file to download
+        save_path (str): Path where the downloaded file will be saved
+        timeout (int): Timeout for the download request in seconds
+
+    Returns:
+        bool: True if download was successful, False otherwise
+    """
+
+    # Send GET request
+    response = requests.get(url, stream=True, timeout=timeout)
+    response.raise_for_status()  # Raise exception for HTTP errors
+
+    # Write content to file
+    with open(save_path, "wb") as f:
+        for chunk in response.iter_content(chunk_size=8192):
+            f.write(chunk)
+
+    print(f"Successfully downloaded: {url} to {save_path}")
+    return True
+
+
+def download_and_patch_output(
+    repo_url_base: str,
+    file_path_in_repo: str,
+    output_path: Optional[str] = None,
+    insert_origin_line: bool = True,
+    insert_origin_line_at: int = 1,
+):
+    """Download the output file from the specified URL and save it locally to use
+    for Sphinx documentation purposes.
+
+    Parameters
+    ----------
+    repo_url_base : str
+        The base URL of the repository, using the raw format (e.g., GitHub).
+    file_path_in_repo : str
+        The file path within the repository. Filename is the default output name.
+    output_path : Optional[str], optional
+        Path where the output file will be saved, by default None
+    insert_origin_line : bool, optional
+        Whether to insert a line indicating the origin of the file, by default True
+    insert_origin_line_at : int, optional
+        The line number at which to insert the origin line, by default 1
+    """
+    # new folders would need to be created if necessary
+    
+    if output_path is None:
+        output_path = Path(file_path_in_repo).name
+    
+    url = PosixPath(repo_url_base) / file_path_in_repo
+    url = str(url)
+    url = url.replace('https:/github.com', 'https://github.com')
+    print(f"Downloading file from: {url}")
+
+    assert download_file(url, output_path)  # prints success message
+
+    with open(output_path, "r", encoding="utf-8") as f:
+        content = f.readlines()
+
+    assert len(content) > 0, "Downloaded file is empty"
+
+    origin_msg = f"> file downloaded from [source]({url})"
+    if insert_origin_line:
+        content.insert(insert_origin_line_at, f"{origin_msg}   \n")
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.writelines(content)
+
+
+if __name__ == "__main__":
+    download_and_patch_output(
+        repo_url_base="https://github.com/biosustain/python_package/raw/refs/heads/main",
+        file_path_in_repo="developing.md",
+        output_path="python/package_template.md",
+        insert_origin_line=True,
+        insert_origin_line_at=2,
+    )

--- a/fetch_files.py
+++ b/fetch_files.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path, PosixPath
 from typing import Optional
 from urllib.parse import urlparse
@@ -35,6 +36,25 @@ def download_file(url, save_path, timeout=20):
     return True
 
 
+def replace_local_links_with_github_links(content: str, repo_url_base: str):
+    """
+    Replace local links in the content with links to the GitHub repository.
+    The regex pattern has two parts
+    1. \[(.*?)\] matches the link text.
+    2. \((?!https?://)([^)]+)\) matches the relative path 
+                                (not starting with http/https).
+                                
+    Replace with main branch URL of the repository.
+    """
+
+    res = re.sub(
+        r"\[(.*?)\]\((?!https?://)([^)]+)\)",
+        f"[\\1]({repo_url_base}/blob/main/\\2)",
+        content,
+    )
+    return res
+
+
 def download_and_patch_output(
     repo_url_base: str,
     file_path_in_repo: str,
@@ -59,13 +79,13 @@ def download_and_patch_output(
         The line number at which to insert the origin line, by default 1
     """
     # new folders would need to be created if necessary
-    
+
     if output_path is None:
         output_path = Path(file_path_in_repo).name
-    
-    url = PosixPath(repo_url_base) / file_path_in_repo
+
+    url = PosixPath(repo_url_base) / "raw/refs/heads/main" / file_path_in_repo
     url = str(url)
-    url = url.replace('https:/github.com', 'https://github.com')
+    url = url.replace("https:/github.com", "https://github.com")
     print(f"Downloading file from: {url}")
 
     assert download_file(url, output_path)  # prints success message
@@ -75,17 +95,23 @@ def download_and_patch_output(
 
     assert len(content) > 0, "Downloaded file is empty"
 
+    # Add hint of the origin of the file
     origin_msg = f"> file downloaded from [source]({url})"
     if insert_origin_line:
         content.insert(insert_origin_line_at, f"{origin_msg}   \n")
 
+    content = "".join(content)  # Convert list to string
+
+    # Replace local links with GitHub links
+    content = replace_local_links_with_github_links(content, repo_url_base)
+
     with open(output_path, "w", encoding="utf-8") as f:
-        f.writelines(content)
+        f.write(content)
 
 
 if __name__ == "__main__":
     download_and_patch_output(
-        repo_url_base="https://github.com/biosustain/python_package/raw/refs/heads/main",
+        repo_url_base="https://github.com/biosustain/python_package",
         file_path_in_repo="developing.md",
         output_path="python/package_template.md",
         insert_origin_line=True,

--- a/index.md
+++ b/index.md
@@ -69,6 +69,7 @@ sphinx/0_overview
 
 python/percent_notebooks
 python/best_practices
+python/package_template
 ```
 
 ```{toctree}

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,2 @@
+# files fetched from other sources
+package_template.md


### PR DESCRIPTION
- [x] fetch description of Python Package template from repo
- [x] patch relative paths with template url

For patching this would be

`[pyproject.toml](pyproject.toml)` should be then
`[pyproject.toml](https://github.com/biosustain/python_package/blob/main/pyproject.toml)`

or a similar URL link